### PR TITLE
add : report of comparison between 2 models

### DIFF
--- a/reports/model_comparison.json
+++ b/reports/model_comparison.json
@@ -1,8 +1,8 @@
 {
   "criterion": "log_loss",
-  "winner": "tuned",
+  "winner": "xgb",
   "model1": {
-    "label": "baseline",
+    "label": "forest",
     "path": "testLib/io/model.pkl",
     "metrics": {
       "log_loss": 2.7233676131084383,
@@ -12,7 +12,7 @@
     }
   },
   "model2": {
-    "label": "tuned",
+    "label": "xgb",
     "path": "models/outcome_model_xgb.pkl",
     "metrics": {
       "log_loss": 0.6562622510809248,


### PR DESCRIPTION
This pull request updates the model comparison report to reflect new model labels and results. The primary change is that the "xgb" model is now identified as the winner based on log loss, replacing the previous "tuned" model. Additionally, the labels for both models have been updated to more accurately reflect their types.

Updates to model comparison results:

* The `winner` field is now set to `"xgb"` instead of `"tuned"` in `reports/model_comparison.json`.
* The label for `model1` is changed from `"baseline"` to `"forest"` in `reports/model_comparison.json`.
* The label for `model2` is changed from `"tuned"` to `"xgb"` in `reports/model_comparison.json`.